### PR TITLE
Added AuthorProminence feature

### DIFF
--- a/correlation_study.py
+++ b/correlation_study.py
@@ -2,7 +2,7 @@ import streamlit as st
 import data_tools as dt
 
 
-def run_correlation_study(raw_docs):
+def run_correlation_study(raw_docs, author_map):
     st.title("Correlation Study")
 
     st.header("1. Dependent Variable Analysis")
@@ -16,6 +16,16 @@ def run_correlation_study(raw_docs):
     st.subheader("Rank vs. Citation Count (Small correlation)")
     dt.correlation(raw_docs, ["Rank", "CitationCount"])
     dt.show_relative_scatter(raw_docs, "Rank", "CitationCount")
+
+    df = dt.add_author_prominence_feature(raw_docs, author_map)
+
+    st.subheader("Rank vs. Author Prominence")
+    dt.correlation(df, ["Rank", "AuthorProminence"])
+    dt.show_relative_scatter(df, "Rank", "AuthorProminence")
+
+    st.subheader("CitationCount vs. Author Prominence")
+    dt.correlation(df, ["CitationCount", "AuthorProminence"])
+    dt.show_relative_scatter(df, "CitationCount", "AuthorProminence")
 
     st.header("2. Independent Variable Analysis")
     st.subheader("DocType")

--- a/data_tools/data_loader.py
+++ b/data_tools/data_loader.py
@@ -37,6 +37,7 @@ def load_dataset(dataset_filename, limit):
     loading_bar = st.progress(0)
     json_data = []
     i = 0
+    author_map = {}
     print("Loading dataset")
     with open(dataset_filename) as file:
         for json_line in file:
@@ -46,7 +47,24 @@ def load_dataset(dataset_filename, limit):
 
             # Extract author id (we don't care about AuthorName and SequenceNumber for now)
             for k, author in enumerate(doc["Authors"]):
-                doc["Author_" + str(k + 1)] = author["AuthorId"]
+                author_id = author["AuthorId"]
+                doc["Author_" + str(k + 1)] = author_id
+                citation_count = doc["CitationCount"]
+
+                if (author_id in author_map):
+                    author_map[author_id]["TotalCitationCount"] += int(citation_count)
+                    author_map[author_id]["PaperCount"] += 1
+                    author_map[author_id]["CitationCounts"][doc["PaperId"]] = int(citation_count)
+                else:
+                    author_map[author_id] = {
+                        "Name": author["Name"],
+                        "TotalCitationCount": int(citation_count),
+                        "PaperCount": 1,
+                        "CitationCounts": {
+                            doc["PaperId"]: int(citation_count)
+                        }
+                    }
+
             del doc["Authors"]
 
             # Map fields of study
@@ -86,4 +104,5 @@ def load_dataset(dataset_filename, limit):
     print("Created DataFrame")
 
     loading_bar.empty()
-    return df
+
+    return df, author_map

--- a/explore.py
+++ b/explore.py
@@ -5,6 +5,7 @@ from data_tools import (
     load_dataset,
     time_it,
     one_hot_encode_authors,
+    add_author_prominence_feature
 )
 
 st.header("Data Exploration")
@@ -22,7 +23,7 @@ docs_limit = st.number_input(
 )
 selected_dataset = st_dataset_selector()
 
-raw_docs = load_dataset(selected_dataset, docs_limit)
+raw_docs, author_map = load_dataset(selected_dataset, docs_limit)
 
 st.subheader("Raw docs shape")
 raw_docs.shape
@@ -35,7 +36,7 @@ st.write(", ".join(raw_docs.columns))
 
 from correlation_study import run_correlation_study
 
-run_correlation_study(raw_docs)
+run_correlation_study(raw_docs, author_map)
 
 
 from distribution_study import run_distribution_study


### PR DESCRIPTION
- AuthorProminence considers the citation count of the paper's authors

Not much correlation at the moment (this is for 250k)...
<img width="857" alt="Screenshot 2020-10-29 at 14 38 37" src="https://user-images.githubusercontent.com/1349225/97617791-96580e80-19f4-11eb-8700-396d8645c635.png">
<img width="871" alt="Screenshot 2020-10-29 at 14 38 42" src="https://user-images.githubusercontent.com/1349225/97617792-96580e80-19f4-11eb-8480-fc72c5e08a75.png">


Two issues with this:
- we don't have the complete set of papers, so some authors might have citations from previous papers that are not included in the dataset
- in this PR we consider the author's prominence to be the total citation counts (excluding the paper we're analyzing), but this will include papers that were published after the paper we're analyzing

Some ideas for improvements:
1. fetch the author's "prominence" from Microsoft's academic graph / Google Scholar to ensure we have a more complete picture
2. Instead of summing/weighting the author prominence, simply one-hot encode whether the paper includes a highly cited author?