### PR TITLE
Optimize load-daataset by optionally using predefined filters

### DIFF
--- a/data_tools/data_loader.py
+++ b/data_tools/data_loader.py
@@ -53,10 +53,16 @@ def strip_unprintable(s):
     return "".join(c for c in s if c.isprintable())
 
 
+def is_doc_included_by_predefined_filters(doc):
+    is_comp_sci = "FieldOfStudy_0" in doc and doc["FieldOfStudy_0"] == "computer science"
+    is_conf_or_journal = doc["DocType"] == "Journal" or doc["DocType"] == "Conference"
+
+    return is_comp_sci and is_conf_or_journal
+
 # Adding allow_output_mutation significantly speeds up
 # the caching: https://github.com/streamlit/streamlit/issues/898
 @st.cache(suppress_st_warning=True, persist=True, allow_output_mutation=True)
-def load_dataset(dataset_filename, limit):
+def load_dataset(dataset_filename, limit, use_predefined_filters = False):
     loading_bar = st.progress(0)
     json_data = []
     i = 0
@@ -66,6 +72,16 @@ def load_dataset(dataset_filename, limit):
     with open(dataset_filename) as file:
         for json_line in file:
             doc = json.loads(json_line)
+
+            # Map fields of study
+            for field_of_study in doc["FieldsOfStudy"]:
+                doc["FieldOfStudy_" + str(field_of_study["Level"])] = field_of_study[
+                    "Name"
+                ]
+            del doc["FieldsOfStudy"]
+
+            if (use_predefined_filters and not is_doc_included_by_predefined_filters(doc)):
+                continue
             doc["Abstract"] = strip_unprintable(doc["Abstract"])
             citation_count = int(doc["CitationCount"])
 
@@ -95,13 +111,6 @@ def load_dataset(dataset_filename, limit):
             years_since_publication = days_since_publication / 365
             doc["YearsSincePublication"] = years_since_publication
             doc["CitationCountPerYear"] = citation_count / years_since_publication
-
-            # Map fields of study
-            for field_of_study in doc["FieldsOfStudy"]:
-                doc["FieldOfStudy_" + str(field_of_study["Level"])] = field_of_study[
-                    "Name"
-                ]
-            del doc["FieldsOfStudy"]
 
             # Extract JournalName from Journal (also contains JournalId, Website)
             if doc["Journal"]:

--- a/data_tools/perf_utils.py
+++ b/data_tools/perf_utils.py
@@ -9,9 +9,9 @@ def time_it(label, fn):
     fn: the function to wrap
     """
 
-    def wrapper(*args):
+    def wrapper(*args, **kwargs):
         start_time = time.perf_counter()
-        result = fn(*args)
+        result = fn(*args, **kwargs)
         end_time = time.perf_counter()
         label_str = str(label(result)) if callable(label) else str(label)
 

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ def feature_selection_page():
     )
     selected_dataset = st_dataset_selector()
 
-    raw_docs, author_map = load_dataset(selected_dataset, docs_limit)
+    raw_docs, author_map = load_dataset(selected_dataset, docs_limit, use_predefined_filters=True)
 
     ##############
     # Extracts available data columns and creates checkboxes

--- a/paper_exploration.py
+++ b/paper_exploration.py
@@ -22,7 +22,7 @@ def paper_exploration_page():
     )
     selected_dataset = st_dataset_selector()
 
-    raw_docs, author_map = load_dataset(selected_dataset, docs_limit)
+    raw_docs, author_map = load_dataset(selected_dataset, docs_limit, use_predefined_filters=True)
 
     # raw_docs = filter_by_field_of_study(raw_docs, "computer science")
 


### PR DESCRIPTION
Instead of loading 5 million articles and then filtering them by field of study / type, this ensures that the filtering can be done up-front.

For now I've enabled pre-defined filtering for paper_exploration & feature selection, but we can add a toggle later if we wish.

Edit: Merging straight away to compile the 5 mill dataset, but let me know if you have any comments.